### PR TITLE
Add links to other relevant repos to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,17 @@ Ready to use queries for the SQL Query Export and/or Data Warehouse features for
 
 ## Other Repositories
 
-Links to other Github repositories that contain scripts and other resources.
+Links to other Github repositories that contain scripts and other resources for Nexpose.
+
+### From Rapid7
+
+- https://github.com/rapid7/recog Service and system fingerprint matchers, many of which are used by Nexpose
+- https://github.com/rapid7/coverage-toolkit A toolkit for creating custom vulnerability content for Nexpose
+
+### From the Community
+
+- https://github.com/BrianWGray/nexpose Generic scripts for managing Nexpose
+- https://github.com/BrianWGray/cmty-nexpose-checks Custom vulnerabiltiy checks for Nexpose
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Links to other Github repositories that contain scripts and other resources for 
 
 - https://github.com/rapid7/recog Service and system fingerprint matchers, many of which are used by Nexpose
 - https://github.com/rapid7/coverage-toolkit A toolkit for creating custom vulnerability content for Nexpose
+- https://github.com/rapid7/nexpose-warehouse-jasper-templates Jaspersoft Studio report templates for Nexpose Data Warehouse
 
 ### From the Community
 


### PR DESCRIPTION
Add links to a couple of Rapid7 repos and @BrianWGray's Nexpose related repos.

@BrianWGray please let me know if you'd prefer to not have these linked here, or if you'd prefer a different format.

Preview the readme here: https://github.com/rapid7/nexpose-resources/blob/e8d503612e6737ba3b841a492bbc19e1c41d9983/README.md