### PR TITLE
script/nexpose-export-import-site-scans - example ruby scripts to export and import site scans between consoles

### DIFF
--- a/scripts/sites/export-import-site-scans/ruby/README.md
+++ b/scripts/sites/export-import-site-scans/ruby/README.md
@@ -1,0 +1,32 @@
+## Site Scan Export/Import Example
+These scripts are intended to show how to use the `nexpose` ruby gem in order to export scans from a site and import them 
+into another site and/or Nexpose console.  They will need to be modified more if advanced features are needed.
+
+#### export-site-scans.rb
+Run the script by passing in the site ID where scans should be exported from:
+```
+> ruby export-site-scans.rb 1
+```
+
+This script results in a site.json file being generated with details about the site that was exported (eg scan template, 
+name, etc) in addition to all the zipped scan files for the site.  An index is used to keep track of scan order (oldest 
+to newest) since the import of scans must follow the same order.
+
+#### import-site-scans.rb
+Run the script without passing any arguments:
+```
+> ruby import-site-scans.rb
+```
+
+This script results in the site being created in the secondary console (will fail if site name already in use) with a 
+name appended with '-import'.  The import defines `local scan engine` for site use and can be used as an example of how 
+configurations can be overridden during the site creation.
+
+In addition, each scan file is imported (oldest to newest) with sleeps added to ensure the import is complete prior to 
+moving on.  
+
+It is also possible to create the site manually prior to the import, comment out line 14 and 15, and add the following 
+with proper site ID defined for import to line 16:
+```
+site_id = 2
+```

--- a/scripts/sites/export-import-site-scans/ruby/export-site-scans.rb
+++ b/scripts/sites/export-import-site-scans/ruby/export-site-scans.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/evn ruby  
+require 'nexpose'
+  
+nsc = Nexpose::Connection.new('localhost-primary', 'nxadmin', 'nxpassword', '3780')
+nsc.login  
+at_exit { nsc.logout }  
+  
+# Allow the user to pass in the site ID to the script.  
+site_id = ARGV[0].to_i  
+  
+# Write the site configuration to a file.  
+site = Nexpose::Site.load(nsc, site_id)
+File.write('site.json', site.to_json)
+  
+# Grab scans and sort by scan end time  
+scans = nsc.site_scan_history(site_id).sort_by { |s| s.end_time }.map { |s| s.scan_id }  
+  
+# Scan IDs are not guaranteed to be in order, so use a proxy number to order them.  
+i = 0  
+scans.each do |scan_id|  
+  nsc.export_scan(scan_id, "scan-#{i}.zip")  
+  i += 1  
+end  

--- a/scripts/sites/export-import-site-scans/ruby/import-site-scans.rb
+++ b/scripts/sites/export-import-site-scans/ruby/import-site-scans.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/evn ruby  
+require 'nexpose'
+  
+nsc = Nexpose::Connection.new('localhost-secondary', 'nxadmin', 'nxpassword', '3780')
+nsc.login  
+at_exit { nsc.logout }  
+ 
+site_bak = JSON.parse(File.read('site.json'), symbolize_names: true)
+site = Nexpose::Site.from_hash(site_bak)
+site.id = -1 
+# Set to use the local scan engine.
+site.name = "#{site.name}-import"
+site.engine_id = nsc.engines.find { |e| e.name == 'Local scan engine' }.id  
+site_id = site.save(nsc)
+puts "Created Site: #{site.name}"
+  
+# Import scans by numerical ordering  
+scans = Dir.glob('scan-*.zip').map { |s| s.gsub(/scan-/, '').gsub(/\.zip/, '').to_i }.sort  
+scans.each do |scan|  
+  zip = "scan-#{scan}.zip"  
+  puts "Importing #{zip}"  
+  nsc.import_scan(site_id, zip)
+  # Poll until scan is complete before attempting to import the next scan.  
+  last_scan = nsc.site_scan_history(site_id).max_by { |s| s.start_time }.scan_id
+  puts "...#{nsc.scan_status(last_scan)}"
+  sleep 60 # Give it plenty of time before importing next
+  while (%w(running integrating).include?(nsc.scan_status(last_scan)))
+    puts "...#{nsc.scan_status(last_scan)}"
+    sleep 60 # Give it plenty of time before importing next
+  end
+  puts "Integration of #{zip} complete"  
+end  


### PR DESCRIPTION
## Description
Provide two ruby scripts to show use of gem in order to export and import scans between Nexpose/InsightVM consoles.   Similar script was previously documented on community site.

README provided for simple explanation of running scripts and intended outcome.

## Motivation and Context
Similar script was previously documented on community site.  Meant to be used as an example for how to import/export scans.


## How Has This Been Tested?
Local testing between two consoles.


## Screenshots (if appropriate):
N/A


## Checklist:
- [x] I have updated the documentation accordingly (if changes are required).
- [x] I am the copyright holder or have permission to publish this content. (For new files)
