### PR TITLE
Refactor aws_discvoery_connection_creator.rb to loop over all configs in aws_configuration.yml

### DIFF
--- a/scripts/discovery_connections/aws_discovery_connection/aws_configuration.yml
+++ b/scripts/discovery_connections/aws_discovery_connection/aws_configuration.yml
@@ -1,6 +1,6 @@
-AWS:
+AWS 0:
   serviceName: amazon-web-services
-  configName: AWSAssetSync
+  configName: AWSAssetSync0
   configurationAttributes:
     valueClass: Object
     objectType: service_configuration
@@ -9,43 +9,70 @@ AWS:
         valueClass: Array
         items:
         - valueClass: String
-          value: US West (Oregon)
-        - valueClass: String
-          value: US East (N. Virginia)
-      consoleInsideAWS:
-        valueClass: Boolean
-        value: false
-      engineInsideAWS:
-        valueClass: Boolean
-        value: true
-      useProxy:
-        valueClass: Boolean
-        value: false
-AWS with console in AWS and multiple ARNs:
-  serviceName: amazon-web-services
-  configName: AwsMultipleARNs
-  configurationAttributes:
-    valueClass: Object
-    objectType: service_configuration
-    properties:
-      region:
-        valueClass: Array
-        items:
-        - valueClass: String
-          value: US East (N. Virginia)
+          value: All regions
       consoleInsideAWS:
         valueClass: Boolean
         value: true
       engineInsideAWS:
         valueClass: Boolean
-        value: true
+        value: false
       arn:
         valueClass: Array
         items:
         - valueClass: String
-          value: 'arn:aws:iam::000000000000:role/ExampleTestRole'
+          value: 'arn:aws:iam::000000000000:role/ExampleTestRole0'
+      useProxy:
+        valueClass: Boolean
+        value: false
+AWS 1:
+  serviceName: amazon-web-services
+  configName: AWSAssetSync1
+  configurationAttributes:
+    valueClass: Object
+    objectType: service_configuration
+    properties:
+      region:
+        valueClass: Array
+        items:
         - valueClass: String
-          value: 'arn:aws:iam::000000000001:role/ExampleTestRoleInDifferentAccount'
+          value: US East (N. Virginia)
+      consoleInsideAWS:
+        valueClass: Boolean
+        value: true
+      engineInsideAWS:
+        valueClass: Boolean
+        value: false
+      arn:
+        valueClass: Array
+        items:
+        - valueClass: String
+          value: 'arn:aws:iam::000000000000:role/ExampleTestRole1'
+      useProxy:
+        valueClass: Boolean
+        value: false
+AWS 2:
+  serviceName: amazon-web-services
+  configName: AWSAssetSync2
+  configurationAttributes:
+    valueClass: Object
+    objectType: service_configuration
+    properties:
+      region:
+        valueClass: Array
+        items:
+        - valueClass: String
+          value: All regions
+      consoleInsideAWS:
+        valueClass: Boolean
+        value: true
+      engineInsideAWS:
+        valueClass: Boolean
+        value: false
+      arn:
+        valueClass: Array
+        items:
+        - valueClass: String
+          value: 'arn:aws:iam::000000000000:role/ExampleTestRole2'
       useProxy:
         valueClass: Boolean
         value: false

--- a/scripts/discovery_connections/aws_discovery_connection/aws_discovery_connection_creator.rb
+++ b/scripts/discovery_connections/aws_discovery_connection/aws_discovery_connection_creator.rb
@@ -3,7 +3,7 @@ require 'yaml'
 require 'eso'
 
 # aws_discovery_connection_creator.rb creates a new AWS Asset Sync discovery connection
-# USAGE: 
+# USAGE:
 #    bundle install
 #    export NEXPOSE_PW=redacted NEXPOSE_AWS_ACCESS_KEY_ID=redacted NEXPOSE_AWS_SECRET_ACCESS_KEY=redacted && bundle exec ruby ./aws_discovery_connection_creator.rb
 
@@ -11,11 +11,8 @@ require 'eso'
 nexpose_host = 'localhost'
 nexpose_username = 'admin'
 nexpose_port = 3780
-# For security's sake, I kept the following in env vars rather than a plaintext file. If you have a bunch of
-# connections to set up, you may want to keep the aws vars in aws_configuration.yml or use some other kind of scheme.
+# For security's sake, pull the password from an environment variable rather than a config file.
 nexpose_password = ENV['NEXPOSE_PW']
-access_key_id = ENV['NEXPOSE_AWS_ACCESS_KEY_ID']
-secret_access_key = ENV['NEXPOSE_AWS_SECRET_ACCESS_KEY']
 
 # Create connection to nexpose console
 @nsc = Nexpose::Connection.new(nexpose_host, nexpose_username, nexpose_password, nexpose_port)
@@ -26,45 +23,53 @@ secret_access_key = ENV['NEXPOSE_AWS_SECRET_ACCESS_KEY']
 # Logout of Nexpose when script Exits
 at_exit { @nsc.logout }
 
-# Create a site for assets to live in
-site = Nexpose::Site.new("unique_site_name")
-site_id = site.save(@nsc)
-
-# Load the discovery connection configuration from a file, name it, and stuff in credentials. There are example `AWS`
-# and `AWS with console in AWS and multiple ARNs` in aws_configuration.yml. You could stuff more in there if desired.
-template_type = ['AWS', 'AWS with console in AWS and multiple ARNs'][0]
-dc_configuration = YAML.load_file('aws_configuration.yml')[template_type]
-dc_configuration['configName'] = "AWSAssetSync-UniqueDisplayName"
-dc_configuration['configurationAttributes']['properties']['accessKeyID'] = {'valueClass' => 'String', 'value'=> access_key_id}
-dc_configuration['configurationAttributes']['properties']['secretAccessKey'] = {'valueClass' => 'String', 'value' => secret_access_key}
-
-# POST the request for a discovery connection configuration
-@configuration_manager = Eso::ConfigurationManager.new(@nsc)
-#@configuration_manager.service_configurations(service_name: "amazon-web-services").each { |cfg| @configuration_manager.delete(cfg["configID"]) }
-request_body = JSON.generate(dc_configuration)
-# If the following fails, make sure that the config is valid (enter it into the UI and `Test Connection`) and that
-# it's not a duplicate of a preexisting config.
-config_id = @configuration_manager.post_service_configuration(request_body)
-
-# POST a sync_aws_assets_with_tags integration option.
-# Integration options are used to use the configuration bits of a discovery connection to perform
-# some type of action -- in this case, syncing the assets from the discovery connection (via config_id) to a site
-# (via site_id). Integration options must be created and then started.
+# Create the configuration_manager which will post new configurations
+configuration_manager = Eso::ConfigurationManager.new(@nsc)
+# Create the integration_option_manager which will post new integration options linked to a configuration
 integration_option_manager = Eso::IntegrationOptionsManager.new(@nsc)
-sync_integration_option = Eso::IntegrationOptionsManager.build_sync_aws_assets_with_tags_option(
-                                                           name: "sync-#{config_id}",
-                                                           # Integration options link a DC config -> site
-                                                           discovery_conn_id: config_id)
-sync_integration_option.site_id = site_id
-sync_integration_option.id = integration_option_manager.create(sync_integration_option.to_json)
-integration_option_manager.start(sync_integration_option.id)
 
-# POST a verify_aws_targets integration option. This integration option is needed to do pre-scan verification
-# of AWS assets. Pre-scan verification is the process of checking that an AWS ip actually (still) belongs to
-# the customer so the customer doesn't scan other companies' assets.
-verify_integration_option = Eso::IntegrationOptionsManager.build_verify_aws_targets_option(
-		name: "verify-#{config_id}",
-		discovery_conn_id: config_id)
-verify_integration_option.site_id = site_id
-verify_integration_option.id = integration_option_manager.create(verify_integration_option.to_json)
-integration_option_manager.start(verify_integration_option.id)
+# Load the discovery connection configurations from a file.
+dc_configurations = YAML.load_file('aws_configuration.yml')
+dc_configurations.each { |dc_label, dc_configuration|
+  puts "Processing #{dc_label}..."
+
+  # Create a site for assets to live in
+  site = Nexpose::Site.new("#{dc_configuration['configName']} Site")
+  site_id = site.save(@nsc)
+
+  # If NEXPOSE_AWS_ACCESS_KEY_ID and NEXPOSE_AWS_SECRET_ACCESS_KEY are set in env vars, use them in the config.
+  if ENV['NEXPOSE_AWS_ACCESS_KEY_ID']
+    dc_configuration['configurationAttributes']['properties']['accessKeyID'] = {'valueClass' => 'String', 'value'=> access_key_id}
+  end
+  if ENV['NEXPOSE_AWS_SECRET_ACCESS_KEY']
+    dc_configuration['configurationAttributes']['properties']['secretAccessKey'] = {'valueClass' => 'String', 'value' => secret_access_key}
+  end
+
+  # POST the request for a discovery connection configuration.
+  # If the following fails, make sure that the config is valid (enter it into the UI and `Test Connection`) and that
+  # it's not a duplicate of a preexisting config.
+  request_body = JSON.generate(dc_configuration)
+  config_id = configuration_manager.post_service_configuration(request_body)
+
+  # POST a sync_aws_assets_with_tags integration option.
+  # Integration options are used to use the configuration bits of a discovery connection to perform
+  # some type of action -- in this case, syncing the assets from the discovery connection (via config_id) to a site
+  # (via site_id). Integration options must be created and then started.
+  sync_integration_option = Eso::IntegrationOptionsManager.build_sync_aws_assets_with_tags_option(
+                                                             name: "sync-#{config_id}",
+                                                             # Integration options link a DC config -> site
+                                                             discovery_conn_id: config_id)
+  sync_integration_option.site_id = site_id
+  sync_integration_option.id = integration_option_manager.create(sync_integration_option.to_json)
+  integration_option_manager.start(sync_integration_option.id)
+
+  # POST a verify_aws_targets integration option. This integration option is needed to do pre-scan verification
+  # of AWS assets. Pre-scan verification is the process of checking that an AWS ip actually (still) belongs to
+  # the customer so the customer doesn't scan other companies' assets.
+  verify_integration_option = Eso::IntegrationOptionsManager.build_verify_aws_targets_option(
+      name: "verify-#{config_id}",
+      discovery_conn_id: config_id)
+  verify_integration_option.site_id = site_id
+  verify_integration_option.id = integration_option_manager.create(verify_integration_option.to_json)
+  integration_option_manager.start(verify_integration_option.id)
+}


### PR DESCRIPTION
## Description
Refactor aws_discovery_connection_creator.rb to loop over all configs in aws_configuration.yml. Make the AWS access & secret access keys optional.

## Motivation and Context
Multiple discovery connections can now be set up from one config file. AWS access & secret access keys aren't necessary when the console is inside AWS.

## How Has This Been Tested?
Local testing against a console host in aws.


## Checklist:
- [/] I have updated the documentation accordingly (if changes are required).
- [ ] I am the copyright holder or have permission to publish this content. (For new files)
